### PR TITLE
Fix: Upgrade openai to resolve httpx compatibility issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.104.1
 uvicorn==0.24.0
 pydantic==2.5.0
-openai==1.3.0
+openai==1.102.0
 python-multipart==0.0.6
 aiofiles==23.2.1
 requests==2.31.0


### PR DESCRIPTION
# Description

## 1. Summary

This pull request resolves a `TypeError` that causes the application to crash on startup. The error is due to a dependency conflict between the pinned version of `openai` (`1.3.0`) and the latest versions of its sub-dependency, `httpx`.

By upgrading `openai` to a more recent version (`1.102.0`), we restore compatibility with modern package versions and ensure the application can start successfully.

## 2. The Problem: A Step-by-Step Reproduction

Following the project's setup instructions on a clean environment currently leads to a fatal error. The exact steps to reproduce the issue are as follows:

1.  **Clone the repository:**
    ```shell
    git clone https://github.com/realtime-ai/blastoff-llm.git blastoff-llm-test
    cd blastoff-llm-test
    ```

2.  **Create and activate a virtual environment:**
    ```shell
    uv venv
    source .venv/bin/activate
    ```

3.  **Install dependencies from `requirements.txt`:**
    ```shell
    uv pip install -r requirements.txt
    ```
    This step installs `openai==1.3.0` as specified, but it also resolves and installs the **latest available version of `httpx`**, which is `0.28.1` in this case.

4.  **Attempt to run the application:**
    ```shell
    python main.py
    ```

5.  **Result: The application crashes immediately with a `TypeError`:**
    ```
    Traceback (most recent call last):
      File "/home/neon/blastoff-llm-test/main.py", line 375, in <module>
        blastoff_llm = BlastOffLLM()
                       ^^^^^^^^^^^^^
      File "/home/neon/blastoff-llm-test/main.py", line 124, in __init__
        self.small_client = AsyncOpenAI(
                            ^^^^^^^^^^^^
      File "/home/neon/blastoff-llm-test/.venv/lib/python3.12/site-packages/openai/_client.py", line 317, in __init__
        super().__init__(
      File "/home/neon/blastoff-llm-test/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1182, in __init__
        self._client = http_client or httpx.AsyncClient(
                                      ^^^^^^^^^^^^^^^^^^
    TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'
    ```

## 3. Root Cause Analysis

The crash is caused by a breaking change in the `httpx` library, which is a dependency of `openai`:

*   The `requirements.txt` file pins `openai==1.3.0`.
*   This version of `openai` does not specify an upper version limit for its `httpx` dependency.
*   Starting with `httpx` version `0.28.0`, the `proxies` keyword argument was removed from the `AsyncClient` constructor.
*   However, `openai==1.3.0` still attempts to pass this `proxies` argument during its initialization, leading to the `TypeError`.

## 4. The Solution and Verification

The solution is to upgrade the `openai` library to a version that is compatible with the modern `httpx` API.

This PR modifies `requirements.txt` to use `openai==1.102.0`.

**Verification Steps:**

1.  After applying the changes in this PR, install the updated dependencies:
    ```shell
    uv pip install -r requirements.txt
    ```

2.  Run the application again:
    ```shell
    python main.py
    ```

3.  **Result: The application now starts successfully.**
    ```
    INFO:     Started server process [293519]
    INFO:     Waiting for application startup.
    INFO:     Application startup complete.
    INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
    ```

This change fixes a critical bug that prevents new users from running the project and ensures a stable dependency tree for the future.